### PR TITLE
Bugfix PolicyShard difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 - Fixed PolicyShard's `difference` to consider `conditions` and `not_conditions` in whether the shards overlap wholly.
 - Updated PolicyShard's `difference` to only add a `difference` shard if there _is_ in fact a difference.
 - Updated PolicyShard's `difference` to add a `PolicyShard` that is identical to self with other's condition as a not_condition if the conditions are not equal.
+- Updated Policyshard's `difference` to create every possible combination of `difference_<ARP>`, `self.effective_<ARP>` and `intersection_<ARP>` and then dedupe the results to accurately compute the difference. (The  test result of `difference/test_policyshard.py::deny_action_and_resource_subsets` is not how I would express it but is accurate.)
 - Fixed PolicyShard equality not considering not_conditions
+- EffectiveARP - If any of other's exclusions excludes something self DOESN'T then self is not a subset of other.
+- EffectiveARP - Fixed `issubset` bug when self was excluded by other.
 
 # 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.5
+# 0.4.4
 
 - Fixed equal `EffectiveARPs` not being considerered subsets of each toher.
 - Fixed PolicyShard's `difference` to consider `conditions` and `not_conditions` in whether the shards overlap wholly.
@@ -8,9 +8,6 @@
 - Fixed PolicyShard equality not considering not_conditions
 - EffectiveARP - If any of other's exclusions excludes something self DOESN'T then self is not a subset of other.
 - EffectiveARP - Fixed `issubset` bug when self was excluded by other.
-
-# 0.4.4
-
 - Consider a `PolicyShard` that has a condition a subset of a `PolicyShard` that doesn't have a condition if all other signs point to it being a subset.
 
 # 0.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.0 
+# 0.4.4
 
 - Consider a `PolicyShard` that has a condition a subset of a `PolicyShard` that doesn't have a condition if all other signs point to it being a subset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 0.5.0 
+
+- Consider a `PolicyShard` that has a condition a subset of a `PolicyShard` that doesn't have a condition if all other signs point to it being a subset.
+
 # 0.4.3
 
-- Fixed bug causing `EffectiveARP` exclusions not to be honoured by `difference` methods
+- Fixed bug causing `EffectiveARP` exclusions not to be honoured by `difference` methods.
 
 # 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.4.5
+
+- Fixed equal `EffectiveARPs` not being considerered subsets of each toher.
+- Fixed PolicyShard's `difference` to consider `conditions` and `not_conditions` in whether the shards overlap wholly.
+- Updated PolicyShard's `difference` to only add a `difference` shard if there _is_ in fact a difference.
+- Updated PolicyShard's `difference` to add a `PolicyShard` that is identical to self with other's condition as a not_condition if the conditions are not equal.
+- Fixed PolicyShard equality not considering not_conditions
+
 # 0.4.4
 
 - Consider a `PolicyShard` that has a condition a subset of a `PolicyShard` that doesn't have a condition if all other signs point to it being a subset.

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -124,7 +124,7 @@ PolicyShard #1 (first dictonary in list) tells us:
 What occurred:
    #. One of the two ``s3:*`` policy shards was removed because it was a duplicate.
 
-Complex Single Policy
+Deny Not Resource Policy
 --------------------------
 .. doctest:: 
 
@@ -143,7 +143,7 @@ Complex Single Policy
    ...         {
    ...             "Effect": "Deny",
    ...             "Action": [
-   ...                 "s3:PutObject",
+   ...                 "s3:*",
    ...             ],
    ...             "NotResource": "arn:aws:s3:::examplebucket/*",
    ...             "Condition": {
@@ -160,10 +160,7 @@ Complex Single Policy
    [
       {
         "effective_action": {
-          "inclusion": "s3:*",
-          "exclusions": [
-            "s3:PutObject"
-          ]
+          "inclusion": "s3:*"
         },
         "effective_resource": {
           "inclusion": "arn:aws:s3:::examplebucket/*"
@@ -177,13 +174,10 @@ Complex Single Policy
       },
       {
         "effective_action": {
-          "inclusion": "s3:PutObject"
+          "inclusion": "s3:*"
         },
         "effective_resource": {
-          "inclusion": "*",
-          "exclusions": [
-            "arn:aws:s3:::examplebucket/*"
-          ]
+          "inclusion": "*"
         },
         "effective_principal": {
           "inclusion": {
@@ -206,17 +200,16 @@ Complex Single Policy
 The output has two policy shards.
 
 PolicyShard #1 (first dictionary in list) tells us:
-   #. Allow ``s3:*`` except for ``s3:PutObject`` 
+   #. Allow ``s3:*`
    #. On ``arn:aws:s3:::examplebucket/*``
    #. No conditions
 
 PolicyShard #2 (second dictionary in list) tells us:
-   #. Allow ``s3:PutObject`` 
-   #. On all resources **except** ``arn:aws:s3:::examplebucket/*``
+   #. Allow ``s3:*`` 
+   #. On all resources
    #. *except* If the condition applies.
 
 What occurred:
    #. ``s3:GetObject`` was removed from the allow because it was totally within ``s3:*``
-   #. ``s3:PutObject`` was added to the ``EffectiveAction``'s ``exclusions`` so it could be split out into a second ``PolicyShard``.
-   #. A new ``PolicyShard`` was created with ``s3:PutObject``
+   #. A new ``PolicyShard`` was created with ``s3:*``
    #. The deny's ``condition`` became a ``not_condition`` on the new ``PolicyShard``.

--- a/policyglass/effective_arp.py
+++ b/policyglass/effective_arp.py
@@ -122,12 +122,21 @@ class EffectiveARP(Generic[T]):
             return True
         if not self.inclusion.issubset(other.inclusion):
             return False
+        if other.in_exclusions(self.inclusion):
+            return False
         if self.in_exclusions(other.inclusion) or any(
             self_exclusion.issubset(other_exclusion)
             for self_exclusion in self.exclusions
             for other_exclusion in other.exclusions
         ):
             return False
+
+        for other_exclusion in other.exclusions:
+            # If any of other's exclusions excludes something self DOESN'T then self is not a subset of other.
+            if other_exclusion.issubset(self.inclusion) and not any(
+                other_exclusion.issubset(self_exclusion) for self_exclusion in self.exclusions
+            ):
+                return False
         return True
 
     def in_exclusions(self, other: T) -> bool:

--- a/policyglass/effective_arp.py
+++ b/policyglass/effective_arp.py
@@ -118,6 +118,8 @@ class EffectiveARP(Generic[T]):
         """
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot compare {self.__class__.__name__} and {other.__class__.__name__}")
+        if self == other:
+            return True
         if not self.inclusion.issubset(other.inclusion):
             return False
         if self.in_exclusions(other.inclusion) or any(

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -189,12 +189,14 @@ class PolicyShard(BaseModel):
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot compare {self.__class__.__name__} and {other.__class__.__name__}")
 
+        if other.conditions and self.conditions != other.conditions:
+            return False
+        if other.not_conditions and self.not_conditions != other.not_conditions:
+            return False
         return (
             self.effective_action.issubset(other.effective_action)
             and self.effective_resource.issubset(other.effective_resource)
             and self.effective_principal.issubset(other.effective_principal)
-            and self.conditions == other.conditions
-            and self.not_conditions == other.not_conditions
             and self.effect == other.effect
         )
 

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -140,41 +140,56 @@ class PolicyShard(BaseModel):
             # Shards do not overlap
             return [self]
 
-        effective_actions = self.effective_action.difference(other.effective_action)
-        effective_resources = self.effective_resource.difference(other.effective_resource)
-        effective_principals = self.effective_principal.difference(other.effective_principal)
+        difference_actions = self.effective_action.difference(other.effective_action)
+        difference_resources = self.effective_resource.difference(other.effective_resource)
+        difference_principals = self.effective_principal.difference(other.effective_principal)
 
-        if not effective_actions and not effective_resources and not effective_principals:
+        if (
+            not difference_actions
+            and not difference_resources
+            and not difference_principals
+            and self.conditions == other.conditions
+            and self.not_conditions == other.not_conditions
+        ):
             # Shards overlap wholly
             return []
+        result = []
+        if difference_actions or difference_resources or difference_principals:
+            # If we have an ARP difference add a new shard to represent that difference
+            effective_actions = difference_actions or [self.effective_action]
+            effective_resources = difference_resources or [self.effective_resource]
+            effective_principals = difference_principals or [self.effective_principal]
+            result = [
+                self.__class__(
+                    effect=self.effect,
+                    effective_action=effective_action,
+                    effective_resource=effective_resource,
+                    effective_principal=effective_principal,
+                    conditions=self.conditions,
+                    not_conditions=self.not_conditions,
+                )
+                for effective_action in effective_actions
+                for effective_resource in effective_resources
+                for effective_principal in effective_principals
+            ]
 
-        result = [
-            self.__class__(
-                effect=self.effect,
-                effective_action=effective_action,
-                effective_resource=effective_resource,
-                effective_principal=effective_principal,
-                conditions=self.conditions,
-                not_conditions=self.not_conditions,
-            )
-            for effective_action in effective_actions or [self.effective_action]
-            for effective_resource in effective_resources or [self.effective_resource]
-            for effective_principal in effective_principals or [self.effective_principal]
-        ]
-
-        if self.conditions != other.conditions:
-            # If the conditions differ return the intersection of the two shards back into the result.
-            # This results in an uncomplicated difference (already in the result) with a conditional intersection.
+        if (other.conditions and self.conditions != other.conditions) or (
+            other.not_conditions and self.not_conditions != other.not_conditions
+        ):
+            # If the other has a condition and it's not identical to self's, then this means that self's effective ARPs
+            # are not negated by other's ARPs if other's condition does not apply.
+            # i.e. we need to add a duplicate self with the other's condition in our not condition.
             result.append(
                 self.__class__(
                     effect=self.effect,
-                    effective_action=intersection_action,
-                    effective_resource=intersection_resource,
-                    effective_principal=intersection_principal,
+                    effective_action=self.effective_action,
+                    effective_resource=self.effective_resource,
+                    effective_principal=self.effective_principal,
                     conditions=self.conditions,
-                    not_conditions=other.conditions,
+                    not_conditions=frozenset(set(self.not_conditions).union(set(other.conditions))),
                 )
             )
+
         return result
 
     def issubset(self, other: object) -> bool:
@@ -188,11 +203,11 @@ class PolicyShard(BaseModel):
         """
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot compare {self.__class__.__name__} and {other.__class__.__name__}")
-
         if other.conditions and self.conditions != other.conditions:
             return False
         if other.not_conditions and self.not_conditions != other.not_conditions:
             return False
+
         return (
             self.effective_action.issubset(other.effective_action)
             and self.effective_resource.issubset(other.effective_resource)
@@ -281,9 +296,11 @@ class PolicyShard(BaseModel):
         """
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot compare {self.__class__.__name__} and {other.__class__.__name__}")
+
         return (
             self.effective_action == other.effective_action
             and self.effective_resource == other.effective_resource
             and self.effective_principal == other.effective_principal
             and self.conditions == other.conditions
+            and self.not_conditions == other.not_conditions
         )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 long_description = re.sub(r":class:`~[^`]+\.([^`]+)`", "\1", long_description)
 
 setup(
-    version="0.4.3",
+    version="0.4.4",
     python_requires=">=3.6.0",
     name="policyglass",
     packages=find_packages(include=["policyglass", "policyglass.*"]),

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -265,6 +265,45 @@ DIFFERENCE_SCENARIOS = {
             )
         ],
     },
+    "deny_action_and_resource_subsets": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+        ),
+        "second": PolicyShard(
+            effect="Deny",
+            effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("arn:aws:s3:::examplebucket/*")),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            not_conditions=frozenset(),
+        ),
+        "result": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(),
+                not_conditions=frozenset(),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(),
+                not_conditions=frozenset(),
+            ),
+        ],
+    },
 }
 
 

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -156,14 +156,14 @@ DIFFERENCE_SCENARIOS = {
     "proper_subset_with_condition": {
         "first": PolicyShard(
             effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_action=EffectiveAction(inclusion=Action("*")),
             effective_resource=EffectiveResource(inclusion=Resource("*")),
             effective_principal=EffectivePrincipal(Principal("AWS", "*")),
             conditions=frozenset(),
         ),
         "second": PolicyShard(
-            effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effect="Deny",
+            effective_action=EffectiveAction(inclusion=Action("*")),
             effective_resource=EffectiveResource(inclusion=Resource("*")),
             effective_principal=EffectivePrincipal(Principal("AWS", "arn:aws:iam::123456789012:root")),
             conditions=frozenset({Condition("Key", "Operator", ["Value"])}),
@@ -171,34 +171,38 @@ DIFFERENCE_SCENARIOS = {
         "result": [
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*")),
-                effective_resource=EffectiveResource(inclusion=Resource("*")),
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
                 effective_principal=EffectivePrincipal(
-                    Principal("AWS", "*"), frozenset({Principal("AWS", "arn:aws:iam::123456789012:root")})
+                    inclusion=Principal(type="AWS", value="*"),
+                    exclusions=frozenset({Principal(type="AWS", value="arn:aws:iam::123456789012:root")}),
                 ),
                 conditions=frozenset(),
+                not_conditions=frozenset(),
             ),
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*")),
-                effective_resource=EffectiveResource(inclusion=Resource("*")),
-                effective_principal=EffectivePrincipal(Principal("AWS", "arn:aws:iam::123456789012:root")),
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
                 conditions=frozenset(),
-                not_conditions=frozenset({Condition("Key", "Operator", ["Value"])}),
+                not_conditions=frozenset({Condition(key="Key", operator="Operator", values=["Value"])}),
             ),
         ],
     },
-    "exact_match_on_inclusion_with_exclusion": {
+    "exact_match_on_inclusion_with_exclusion_and_condition": {
         "first": PolicyShard(
             effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_action=EffectiveAction(inclusion=Action("*")),
             effective_resource=EffectiveResource(inclusion=Resource("*")),
             effective_principal=EffectivePrincipal(Principal("AWS", "*")),
             conditions=frozenset(),
         ),
         "second": PolicyShard(
             effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_action=EffectiveAction(inclusion=Action("*")),
             effective_resource=EffectiveResource(
                 inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::DOC-EXAMPLE-BUCKET/*")})
             ),
@@ -208,21 +212,57 @@ DIFFERENCE_SCENARIOS = {
         "result": [
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*")),
-                effective_resource=EffectiveResource(inclusion=Resource("arn:aws:s3:::DOC-EXAMPLE-BUCKET/*")),
-                effective_principal=EffectivePrincipal(Principal("AWS", "*")),
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::DOC-EXAMPLE-BUCKET/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
                 conditions=frozenset(),
+                not_conditions=frozenset(),
             ),
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*")),
-                effective_resource=EffectiveResource(
-                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::DOC-EXAMPLE-BUCKET/*")})
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                effective_principal=EffectivePrincipal(Principal("AWS", "*")),
                 conditions=frozenset(),
-                not_conditions=frozenset({Condition("Key", "Operator", ["Value"])}),
+                not_conditions=frozenset({Condition(key="Key", operator="Operator", values=["Value"])}),
             ),
+        ],
+    },
+    "simple_deny_with_exclusion": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+        ),
+        "second": PolicyShard(
+            effect="Deny",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            not_conditions=frozenset(),
+        ),
+        "result": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(),
+                not_conditions=frozenset(),
+            )
         ],
     },
 }

--- a/tests/unit/issubset/test_effective_action.py
+++ b/tests/unit/issubset/test_effective_action.py
@@ -18,6 +18,12 @@ def test_issubset_simple_true():
     assert EffectiveAction(Action("s3:getObject")).issubset(EffectiveAction(Action("s3:getObject")))
 
 
+def test_issubset_exclusion_true():
+    assert EffectiveAction(Action("s3:*"), frozenset({Action("s3:getObject")})).issubset(
+        EffectiveAction(Action("s3:*"), frozenset({Action("s3:getObject")}))
+    )
+
+
 def test_issubset_excluded_action():
     a = EffectiveAction(Action("s3:*"), frozenset({Action("s3:get*")}))
     b = EffectiveAction(Action("s3:getObject"))

--- a/tests/unit/issubset/test_effective_action.py
+++ b/tests/unit/issubset/test_effective_action.py
@@ -46,3 +46,10 @@ def test_union_complex_overlap():
     b = EffectiveAction(Action("s3:*"), frozenset({Action("s3:get*")}))
 
     assert a.issubset(b) is False
+
+
+def test_exclusion_not_subset_of_no_exclusion():
+
+    a = EffectiveAction(inclusion=Action("*"), exclusions=frozenset())
+    b = EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:getobject")}))
+    assert a.issubset(b) is False

--- a/tests/unit/issubset/test_effective_principal.py
+++ b/tests/unit/issubset/test_effective_principal.py
@@ -1,0 +1,10 @@
+from policyglass import EffectivePrincipal, Principal
+
+
+def test_excluded():
+    principal_a = EffectivePrincipal(Principal("AWS", "arn:aws:iam::123456789012:role/RoleName"))
+    principal_b = EffectivePrincipal(
+        Principal("AWS", "*"), frozenset({Principal("AWS", "arn:aws:iam::123456789012:root")})
+    )
+
+    assert not principal_a.issubset(principal_b)

--- a/tests/unit/issubset/test_policy_shard.py
+++ b/tests/unit/issubset/test_policy_shard.py
@@ -23,17 +23,23 @@ POLICYS_SHARD_ISSUBSET_SCENARIOS = {
     "exactly_equal": [
         PolicyShard(
             effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
             conditions=frozenset(),
+            not_conditions=frozenset(),
         ),
         PolicyShard(
             effect="Allow",
-            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
             conditions=frozenset(),
+            not_conditions=frozenset(),
         ),
     ],
     "exactly_equal_but_condition": [
@@ -43,6 +49,22 @@ POLICYS_SHARD_ISSUBSET_SCENARIOS = {
             effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
             conditions=frozenset({Condition(key="TestKey", operator="TestOperator", values=["TestValue"])}),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+        ),
+    ],
+    "exactly_equal_but_not_condition": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            not_conditions=frozenset({Condition(key="TestKey", operator="TestOperator", values=["TestValue"])}),
         ),
         PolicyShard(
             effect="Allow",

--- a/tests/unit/issubset/test_policy_shard.py
+++ b/tests/unit/issubset/test_policy_shard.py
@@ -115,6 +115,44 @@ POLICY_SHARD_NOT_ISSUBSET_SCENARIOS = {
             conditions=frozenset(),
         ),
     ],
+    "action_not_subset_resource_is": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+    ],
+    "equal_except_for_exclusion": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_resource=EffectiveResource(inclusion=Resource("*")),
+            effective_principal=EffectivePrincipal(Principal("AWS", "arn:aws:iam::123456789012:role/RoleName")),
+            conditions=frozenset(),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_resource=EffectiveResource(inclusion=Resource("*")),
+            effective_principal=EffectivePrincipal(
+                Principal("AWS", "*"), frozenset({Principal("AWS", "arn:aws:iam::123456789012:root")})
+            ),
+            conditions=frozenset(),
+        ),
+    ],
 }
 
 

--- a/tests/unit/issubset/test_policy_shard.py
+++ b/tests/unit/issubset/test_policy_shard.py
@@ -1,6 +1,7 @@
 import pytest
 
 from policyglass import Action, EffectiveAction, EffectivePrincipal, EffectiveResource, PolicyShard, Principal, Resource
+from policyglass.condition import Condition
 
 POLICYS_SHARD_ISSUBSET_SCENARIOS = {
     "smaller": [
@@ -26,6 +27,22 @@ POLICYS_SHARD_ISSUBSET_SCENARIOS = {
             effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
             conditions=frozenset(),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+        ),
+    ],
+    "exactly_equal_but_condition": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset({Condition(key="TestKey", operator="TestOperator", values=["TestValue"])}),
         ),
         PolicyShard(
             effect="Allow",

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -168,10 +168,8 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
             ),
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
-                effective_resource=EffectiveResource(
-                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
-                ),
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
@@ -194,6 +192,138 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                 conditions=frozenset(),
                 not_conditions=frozenset(),
             ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(
+            #         inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
+            #     ),
+            #     effective_resource=EffectiveResource(
+            #         inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+            #     ),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(
+            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            #     ),
+            #     not_conditions=frozenset(),
+            # ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+            #     effective_resource=EffectiveResource(
+            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            #     ),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(
+            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            #     ),
+            #     not_conditions=frozenset(
+            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+            #     ),
+            # ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
+            #     effective_resource=EffectiveResource(
+            #         inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+            #     ),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(),
+            #     not_conditions=frozenset(),
+            # ),
+        ],
+    },
+    "identical_except_different_conditions": {
+        "input": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                not_conditions=frozenset(),
+            ),
+            PolicyShard(
+                effect="Deny",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*")),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+                not_conditions=frozenset(),
+            ),
+        ],
+        "expected": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                not_conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+            ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            #     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(
+            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            #     ),
+            #     not_conditions=frozenset(
+            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+            #     ),
+            # ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            #     effective_resource=EffectiveResource(
+            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            #     ),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(
+            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            #     ),
+            #     not_conditions=frozenset(),
+            # ),
+            # PolicyShard(
+            #     effect="Allow",
+            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            #     effective_resource=EffectiveResource(
+            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            #     ),
+            #     effective_principal=EffectivePrincipal(
+            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+            #     ),
+            #     conditions=frozenset(
+            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            #     ),
+            #     not_conditions=frozenset(
+            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+            #     ),
+            # ),
         ],
     },
 }

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -117,49 +117,82 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                conditions=frozenset(),
+                conditions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                not_conditions=frozenset(),
             ),
             PolicyShard(
-                effect="Deny",
-                effective_action=EffectiveAction(
-                    inclusion=Action("s3:Get*"), exclusions=frozenset({Action("s3:GetObject")})
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
                 ),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                conditions=frozenset({Condition("s3:x-amz-server-side-encryption", "StringNotEquals", ["AES256"])}),
+                conditions=frozenset(),
+                not_conditions=frozenset(),
+            ),
+            PolicyShard(
+                effect="Deny",
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+                not_conditions=frozenset(),
             ),
         ],
         "expected": [
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:Get*")})),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_action=EffectiveAction(
+                    inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
+                ),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                conditions=frozenset(),
+                conditions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                not_conditions=frozenset(),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                not_conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
             ),
             PolicyShard(
                 effect="Allow",
                 effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
                 conditions=frozenset(),
-            ),
-            PolicyShard(
-                effect="Allow",
-                effective_action=EffectiveAction(
-                    inclusion=Action("s3:Get*"), exclusions=frozenset({Action("s3:GetObject")})
-                ),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
-                effective_principal=EffectivePrincipal(
-                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-                ),
-                not_conditions=frozenset({Condition("s3:x-amz-server-side-encryption", "StringNotEquals", ["AES256"])}),
+                not_conditions=frozenset(),
             ),
         ],
     },
@@ -170,5 +203,5 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
     "_, input, expected",
     [(name, value["input"], value["expected"]) for name, value in POLICY_SHARDS_EFFECT_SCENARIOS.items()],
 )
-def test_policy_shards_effect_simple(_, input, expected):
+def test_policy_shards_effect(_, input, expected):
     assert policy_shards_effect(input) == expected

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -136,7 +136,7 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
             ),
             PolicyShard(
                 effect="Deny",
-                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
                     inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
                 ),
@@ -152,9 +152,7 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
         "expected": [
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(
-                    inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
-                ),
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
                     inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
                 ),
@@ -192,50 +190,6 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                 conditions=frozenset(),
                 not_conditions=frozenset(),
             ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(
-            #         inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
-            #     ),
-            #     effective_resource=EffectiveResource(
-            #         inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
-            #     ),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(
-            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-            #     ),
-            #     not_conditions=frozenset(),
-            # ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
-            #     effective_resource=EffectiveResource(
-            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
-            #     ),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(
-            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-            #     ),
-            #     not_conditions=frozenset(
-            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
-            #     ),
-            # ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
-            #     effective_resource=EffectiveResource(
-            #         inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
-            #     ),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(),
-            #     not_conditions=frozenset(),
-            # ),
         ],
     },
     "identical_except_different_conditions": {
@@ -280,50 +234,6 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                     {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
                 ),
             ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-            #     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(
-            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-            #     ),
-            #     not_conditions=frozenset(
-            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
-            #     ),
-            # ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-            #     effective_resource=EffectiveResource(
-            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
-            #     ),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(
-            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-            #     ),
-            #     not_conditions=frozenset(),
-            # ),
-            # PolicyShard(
-            #     effect="Allow",
-            #     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-            #     effective_resource=EffectiveResource(
-            #         inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
-            #     ),
-            #     effective_principal=EffectivePrincipal(
-            #         inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-            #     ),
-            #     conditions=frozenset(
-            #         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-            #     ),
-            #     not_conditions=frozenset(
-            #         {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
-            #     ),
-            # ),
         ],
     },
 }


### PR DESCRIPTION
- Fixed equal `EffectiveARPs` not being considerered subsets of each toher.
- Fixed PolicyShard's `difference` to consider `conditions` and `not_conditions` in whether the shards overlap wholly.
- Updated PolicyShard's `difference` to only add a `difference` shard if there _is_ in fact a difference.
- Updated PolicyShard's `difference` to add a `PolicyShard` that is identical to self with other's condition as a not_condition if the conditions are not equal.
- Updated Policyshard's `difference` to create every possible combination of `difference_<ARP>`, `self.effective_<ARP>` and `intersection_<ARP>` and then dedupe the results to accurately compute the difference. (The  test result of `difference/test_policyshard.py::deny_action_and_resource_subsets` is not how I would express it but is accurate.)
- Fixed PolicyShard equality not considering not_conditions
- EffectiveARP - If any of other's exclusions excludes something self DOESN'T then self is not a subset of other.
- EffectiveARP - Fixed `issubset` bug when self was excluded by other.
- Consider a `PolicyShard` that has a condition a subset of a `PolicyShard` that doesn't have a condition if all other signs point to it being a subset.