### PR TITLE
Delineate intersecting shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `dedupe_result` param to `difference` method on `PolicyShard` to allow merging of intersecting shards that are not subsets of one another.
 - Added `intersection` to `PolicyShard`.
 - Prevent attempting to calculate the difference between a Deny shard and an Allow shard. Other way makes sense as that's effective permission.
+- Updated PolicyShard implementation to Support pydantic 1.9
 
 # 0.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.0
 
-- Updated `dedupe_policy_shards` to reduce the size of `PolicyShard`s which have conditions whose ARPs intersect with ones without conditions.
+- Renamed `dedupe_policy_shards` to `dedupe_policy_shard_subsets` to differentiate it from `delineate_intersecting_shards`.
+- Added `delineate_intersecting_shards` to reduce the size of `PolicyShard`s which have conditions whose ARPs intersect with ones without conditions.
     This helps clear up [#10](https://github.com/CloudWanderer-io/PolicyGlass/issues/10)
 - Improved `issubset` on `PolicyShard` to recognise that a shard without conditions CANNOT be a subset of a shard with conditions.
 - Added `<` and `>` to `PolicyShard`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Ensured that Conditions are always treated as a set not a list.
 - Ensured that Condition's Operator, Key, Values are always of type ConditionOperator, ConditionKey and ConditionValue.
 - Corrected bug in `CaseInsensitiveString` that caused it to generate case sensitive hashes.
+- Added `dedupe_result` param to `difference` method on `PolicyShard` to allow merging of intersecting shards that are not subsets of one another.
+- Added `intersection` to `PolicyShard`.
 
 # 0.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 - Improved `issubset` on `PolicyShard` to recognise that a shard without conditions CANNOT be a subset of a shard with conditions.
 - Added `<` and `>` to `PolicyShard`.
 - Updated `difference` on `PolicyShard` so that it only adds `other`'s conditions to `self`'s not_conditions if self is allow and other is deny.
-
+- Added documentation on how PolicyShard dedupe works
+- Renamed `ConditionCollection` to `RawConditionCollection`
+- Ensured that Conditions are always treated as a set not a list.
+- Ensured that Condition's Operator, Key, Values are always of type ConditionOperator, ConditionKey and ConditionValue.
+- Corrected bug in `CaseInsensitiveString` that caused it to generate case sensitive hashes.
 
 # 0.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Corrected bug in `CaseInsensitiveString` that caused it to generate case sensitive hashes.
 - Added `dedupe_result` param to `difference` method on `PolicyShard` to allow merging of intersecting shards that are not subsets of one another.
 - Added `intersection` to `PolicyShard`.
+- Prevent attempting to calculate the difference between a Deny shard and an Allow shard. Other way makes sense as that's effective permission.
 
 # 0.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.5.0
+
+- Updated `dedupe_policy_shards` to reduce the size of `PolicyShard`s which have conditions whose ARPs intersect with ones without conditions.
+    This helps clear up [#10](https://github.com/CloudWanderer-io/PolicyGlass/issues/10)
+- Improved `issubset` on `PolicyShard` to recognise that a shard without conditions CANNOT be a subset of a shard with conditions.
+- Added `<` and `>` to `PolicyShard`.
+- Updated `difference` on `PolicyShard` so that it only adds `other`'s conditions to `self`'s not_conditions if self is allow and other is deny.
+
+
 # 0.4.7
 
 - Fixed case insensitive `fnmatch` for resources

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Let's take two policies, *a* and *b* and pit them against each other.
 
 .. doctest:: 
 
-   >>> from policyglass import Policy, dedupe_policy_shards, policy_shards_effect
+   >>> from policyglass import Policy, policy_shards_effect
    >>> policy_a = Policy(**{
    ...     "Version": "2012-10-17",
    ...     "Statement": [

--- a/doc_source/class_reference.rst
+++ b/doc_source/class_reference.rst
@@ -13,4 +13,4 @@ Class Reference
     class_reference/principal
     class_reference/condition
     class_reference/understanding_effective_actions
-    
+    class_reference/understanding_policy_shards    

--- a/doc_source/class_reference/understanding_policy_shards.rst
+++ b/doc_source/class_reference/understanding_policy_shards.rst
@@ -36,23 +36,23 @@ Let's consider this scenario
     ...     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
     ...     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
     ...     effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
-    ...     conditions=FrozenConditionCollection(
+    ...     conditions=frozenset(
     ...         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
     ...     ),
-    ...     not_conditions=FrozenConditionCollection(),
+    ...     not_conditions=frozenset(),
     ... )
     >>> shard_b = PolicyShard(
     ...     effect="Allow",
     ...     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
     ...     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
     ...     effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
-    ...     conditions=FrozenConditionCollection(
+    ...     conditions=frozenset(
     ...         {
     ...             Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
     ...             Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
     ...         }
     ...     ),
-    ...     not_conditions=FrozenConditionCollection(),
+    ...     not_conditions=frozenset(),
     ... )
 
 Shard A

--- a/doc_source/class_reference/understanding_policy_shards.rst
+++ b/doc_source/class_reference/understanding_policy_shards.rst
@@ -4,10 +4,10 @@ Understanding Policy Shards
 Dedupe & Merge
 --------------------
 
-:class:`policyglass.policy_shard.PolicyShard` objects need to go through two phases to correct their sizes.
+:class:`~policyglass.policy_shard.PolicyShard` objects need to go through two phases to correct their sizes.
 
-1. Dedupe using :func:`policyglass.policy_shard.dedupe_policy_shard_subsets`
-2. Merge using :func:`policyglass.policy_shard.delineate_intersecting_shards`
+1. Dedupe using :func:`~policyglass.policy_shard.dedupe_policy_shard_subsets`
+2. Merge using :func:`~policyglass.policy_shard.delineate_intersecting_shards`
 
 The first collapses all PolicyShards which are subsets of each other into each other, in other words eliminating 
 all smaller PolicyShards that can fit into bigger PolicyShards.
@@ -28,7 +28,6 @@ Let's consider this scenario
     >>> from policyglass import PolicyShard
     >>> from policyglass.action import Action, EffectiveAction
     >>> from policyglass.condition import Condition
-    >>> from policyglass.policy_shard import delineate_intersecting_shards
     >>> from policyglass.principal import EffectivePrincipal, Principal
     >>> from policyglass.resource import EffectiveResource, Resource
     >>> shard_a = PolicyShard(
@@ -68,3 +67,27 @@ This means that.
 #. Because Shard A and Shard B both have conditions they can never be considered subsets of one another even during the decomposition process
 #. They do intersect because every part of ``s3:*`` apart from ``s3:PutObject`` is less restrictively allowed by Shard A
 #. We want to reduce the scope of Shard B to just ``s3:PutObject``
+
+To do this we use :func:`~policyglass.policy_shard.delineate_intersecting_shards`
+
+.. doctest:: 
+
+    >>> from policyglass.policy_shard import delineate_intersecting_shards
+    >>> shard_b_delineated, shard_a_delineated = delineate_intersecting_shards([shard_a, shard_b])
+    >>> print(shard_a_delineated)
+    PolicyShard(effect='Allow', 
+        effective_action=EffectiveAction(inclusion=Action('s3:*'), exclusions=frozenset({Action('s3:PutObject')})), 
+        effective_resource=EffectiveResource(inclusion=Resource('*'), exclusions=frozenset()),
+        effective_principal=EffectivePrincipal(inclusion=Principal(type='AWS', value='*'), exclusions=frozenset()), 
+        conditions=frozenset({Condition(key='aws:PrincipalOrgId', operator='StringNotEquals', values=['o-123456'])}), 
+        not_conditions=frozenset())
+    >>> print(shard_b_delineated)
+    PolicyShard(effect='Allow', 
+        effective_action=EffectiveAction(inclusion=Action('s3:PutObject'), exclusions=frozenset()), 
+        effective_resource=EffectiveResource(inclusion=Resource('*'), exclusions=frozenset()), 
+        effective_principal=EffectivePrincipal(inclusion=Principal(type='AWS', value='*'), exclusions=frozenset()), 
+        conditions=frozenset({Condition(key='aws:PrincipalOrgId', operator='StringNotEquals', values=['o-123456']),
+            Condition(key='s3:x-amz-server-side-encryption', operator='StringEquals', values=['AES256'])}), 
+        not_conditions=frozenset())
+
+You'll notice that the intersection has been removed, and Shard B now only has ``s3:PutObject`` as the rest of ``s3:*`` was covered by Shard A.

--- a/doc_source/class_reference/understanding_policy_shards.rst
+++ b/doc_source/class_reference/understanding_policy_shards.rst
@@ -1,0 +1,70 @@
+Understanding Policy Shards
+==================================
+
+Dedupe & Merge
+--------------------
+
+:class:`policyglass.policy_shard.PolicyShard` objects need to go through two phases to correct their sizes.
+
+1. Dedupe using :func:`policyglass.policy_shard.dedupe_policy_shard_subsets`
+2. Merge using :func:`policyglass.policy_shard.dedupe_policy_shards`
+
+The first collapses all PolicyShards which are subsets of each other into each other, in other words eliminating 
+all smaller PolicyShards that can fit into bigger PolicyShards.
+
+The second reverses that where necessary, identifying shards that are not subsets of each other but nonetheless 
+have some intersection and therefore duplicate the permissions space.
+
+When does a PolicyShard intesect without being a subset?
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This is a departure from EffectiveARPs (Action, Resource, Principal) objects which by contrast cannot intersect without
+being subsets. 
+
+Let's consider this scenario
+
+.. doctest:: 
+
+    >>> from policyglass import PolicyShard
+    >>> from policyglass.action import Action, EffectiveAction
+    >>> from policyglass.condition import Condition
+    >>> from policyglass.policy_shard import dedupe_policy_shards
+    >>> from policyglass.principal import EffectivePrincipal, Principal
+    >>> from policyglass.resource import EffectiveResource, Resource
+    >>> shard_a = PolicyShard(
+    ...     effect="Allow",
+    ...     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+    ...     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+    ...     effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+    ...     conditions=FrozenConditionCollection(
+    ...         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+    ...     ),
+    ...     not_conditions=FrozenConditionCollection(),
+    ... )
+    >>> shard_b = PolicyShard(
+    ...     effect="Allow",
+    ...     effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+    ...     effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+    ...     effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+    ...     conditions=FrozenConditionCollection(
+    ...         {
+    ...             Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+    ...             Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+    ...         }
+    ...     ),
+    ...     not_conditions=FrozenConditionCollection(),
+    ... )
+
+Shard A
+    #. Has a single condition
+    #. Excludes ``s3:PutObject``
+
+Shard B
+    #. Has two conditions, one of which is the same as Shard A
+    #. Does not exclude ``s3:PutObject``
+
+This means that.
+
+#. Because Shard A and Shard B both have conditions they can never be considered subsets of one another even during the decomposition process
+#. They do intersect because every part of ``s3:*`` apart from ``s3:PutObject`` is less restrictively allowed by Shard A
+#. We want to reduce the scope of Shard B to just ``s3:PutObject``

--- a/doc_source/class_reference/understanding_policy_shards.rst
+++ b/doc_source/class_reference/understanding_policy_shards.rst
@@ -7,7 +7,7 @@ Dedupe & Merge
 :class:`policyglass.policy_shard.PolicyShard` objects need to go through two phases to correct their sizes.
 
 1. Dedupe using :func:`policyglass.policy_shard.dedupe_policy_shard_subsets`
-2. Merge using :func:`policyglass.policy_shard.dedupe_policy_shards`
+2. Merge using :func:`policyglass.policy_shard.delineate_intersecting_shards`
 
 The first collapses all PolicyShards which are subsets of each other into each other, in other words eliminating 
 all smaller PolicyShards that can fit into bigger PolicyShards.
@@ -28,7 +28,7 @@ Let's consider this scenario
     >>> from policyglass import PolicyShard
     >>> from policyglass.action import Action, EffectiveAction
     >>> from policyglass.condition import Condition
-    >>> from policyglass.policy_shard import dedupe_policy_shards
+    >>> from policyglass.policy_shard import delineate_intersecting_shards
     >>> from policyglass.principal import EffectivePrincipal, Principal
     >>> from policyglass.resource import EffectiveResource, Resource
     >>> shard_a = PolicyShard(

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -154,8 +154,7 @@ Deny Not Resource Policy
    ...         }
    ...     ]
    ... })
-   >>> deduped_shards = dedupe_policy_shards(policy_a.policy_shards)
-   >>> shards_effect = policy_shards_effect(deduped_shards)
+   >>> shards_effect = dedupe_policy_shards(policy_shards_effect(policy_a.policy_shards))
    >>> print(policy_shards_to_json(shards_effect, exclude_defaults=True, indent=2))
    [
       {
@@ -177,7 +176,10 @@ Deny Not Resource Policy
           "inclusion": "s3:*"
         },
         "effective_resource": {
-          "inclusion": "*"
+          "inclusion": "*",
+          "exclusions": [
+            "arn:aws:s3:::examplebucket/*"
+          ]
         },
         "effective_principal": {
           "inclusion": {

--- a/doc_source/examples.rst
+++ b/doc_source/examples.rst
@@ -16,7 +16,7 @@ Simple
 
 .. doctest:: 
 
-   >>> from policyglass import Policy, dedupe_policy_shards, policy_shards_effect, policy_shards_to_json
+   >>> from policyglass import Policy, delineate_intersecting_shards, policy_shards_effect, policy_shards_to_json
    >>> policy_a = Policy(**{
    ...     "Version": "2012-10-17",
    ...     "Statement": [
@@ -74,7 +74,7 @@ De-duplicate
 
 .. doctest:: 
 
-   >>> from policyglass import Policy, dedupe_policy_shards, policy_shards_to_json
+   >>> from policyglass import Policy, delineate_intersecting_shards, policy_shards_to_json
    >>> policy_a = Policy(**{
    ...     "Version": "2012-10-17",
    ...     "Statement": [
@@ -99,7 +99,7 @@ De-duplicate
    ...         }
    ...     ]
    ... })
-   >>> policy_shards = dedupe_policy_shards([*policy_a.policy_shards, *policy_b.policy_shards])
+   >>> policy_shards = delineate_intersecting_shards([*policy_a.policy_shards, *policy_b.policy_shards])
    >>> print(policy_shards_to_json(policy_shards, exclude_defaults=True, indent=2))
    [
       {
@@ -128,7 +128,7 @@ Deny Not Resource Policy
 --------------------------
 .. doctest:: 
 
-   >>> from policyglass import Policy, dedupe_policy_shards, policy_shards_effect, policy_shards_to_json
+   >>> from policyglass import Policy, delineate_intersecting_shards, policy_shards_effect, policy_shards_to_json
    >>> policy_a = Policy(**{
    ...     "Version": "2012-10-17",
    ...     "Statement": [
@@ -154,7 +154,7 @@ Deny Not Resource Policy
    ...         }
    ...     ]
    ... })
-   >>> shards_effect = dedupe_policy_shards(policy_shards_effect(policy_a.policy_shards))
+   >>> shards_effect = delineate_intersecting_shards(policy_shards_effect(policy_a.policy_shards))
    >>> print(policy_shards_to_json(shards_effect, exclude_defaults=True, indent=2))
    [
       {

--- a/policyglass/__init__.py
+++ b/policyglass/__init__.py
@@ -1,6 +1,6 @@
 """PolicyGlass."""
 from .action import Action, EffectiveAction
-from .condition import Condition, ConditionCollection, ConditionKey, ConditionOperator, ConditionValue
+from .condition import Condition, ConditionKey, ConditionOperator, ConditionValue, RawConditionCollection
 from .policy import Policy
 from .policy_shard import PolicyShard, dedupe_policy_shards, policy_shards_effect, policy_shards_to_json
 from .principal import EffectivePrincipal, Principal, PrincipalCollection, PrincipalType, PrincipalValue
@@ -21,7 +21,7 @@ __all__ = [
     "ConditionKey",
     "ConditionOperator",
     "ConditionValue",
-    "ConditionCollection",
+    "RawConditionCollection",
     "EffectiveAction",
     "EffectiveResource",
     "EffectivePrincipal",

--- a/policyglass/__init__.py
+++ b/policyglass/__init__.py
@@ -2,7 +2,7 @@
 from .action import Action, EffectiveAction
 from .condition import Condition, ConditionKey, ConditionOperator, ConditionValue, RawConditionCollection
 from .policy import Policy
-from .policy_shard import PolicyShard, dedupe_policy_shards, policy_shards_effect, policy_shards_to_json
+from .policy_shard import PolicyShard, delineate_intersecting_shards, policy_shards_effect, policy_shards_to_json
 from .principal import EffectivePrincipal, Principal, PrincipalCollection, PrincipalType, PrincipalValue
 from .resource import EffectiveResource, Resource
 from .statement import Statement
@@ -27,6 +27,6 @@ __all__ = [
     "EffectivePrincipal",
     "PolicyShard",
     "policy_shards_effect",
-    "dedupe_policy_shards",
+    "delineate_intersecting_shards",
     "policy_shards_to_json",
 ]

--- a/policyglass/effective_arp.py
+++ b/policyglass/effective_arp.py
@@ -93,7 +93,7 @@ class EffectiveARP(Generic[T]):
             other: The object to intersect with this one.
 
         Raises:
-            ValueError: if ``other`` is not hte same type as this object.
+            ValueError: if ``other`` is not the same type as this object.
         """
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot intersect {self.__class__.__name__} with {other.__class__.__name__}")

--- a/policyglass/effective_arp.py
+++ b/policyglass/effective_arp.py
@@ -209,7 +209,6 @@ class EffectiveARP(Generic[T]):
         """
         if not isinstance(other, self.__class__):
             raise ValueError(f"Cannot compare {self.__class__.__name__} and {other.__class__.__name__}")
-        print(self.issubset(other))
         return self.issubset(other) and self != other
 
     def __gt__(self, other: object) -> bool:

--- a/policyglass/models.py
+++ b/policyglass/models.py
@@ -19,7 +19,7 @@ class CaseInsensitiveString(str):
 
     def __hash__(self) -> int:
         """Compute the hash for this object."""
-        return super().__hash__()
+        return hash(self.lower())
 
     def __repr__(self) -> str:
         """Return an instantiable representation of this object."""

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -281,9 +281,9 @@ class PolicyShard(BaseModel):
             # If the other has a condition and it's not identical to self's, then there is difference
             # such that self's conditions appliy and other's conditions do not.
             # i.e. we need to add another PolicyShard that is ALL the ARP differences
-            # and if other is Deny and self is Allow we must
+            # If self is Allow and other is Deny we must add the deny's conditions as not_conditions.
             not_conditions = self.not_conditions
-            if other.effect == "Deny" and self.effect == "Allow":
+            if self.effect == "Allow" and other.effect == "Deny":
                 not_conditions = frozenset(self.not_conditions.union(other.conditions))
             result.append(
                 self.__class__(

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -35,7 +35,7 @@ def dedupe_policy_shard_subsets(shards: Iterable["PolicyShard"], check_reverse: 
     return deduped_shards
 
 
-def dedupe_policy_shards(shards: Iterable["PolicyShard"], check_reverse: bool = True) -> List["PolicyShard"]:
+def delineate_intersecting_shards(shards: Iterable["PolicyShard"], check_reverse: bool = True) -> List["PolicyShard"]:
     """Dedupe policy shards that are subsets of each other and remove intersections.
 
     Parameters:
@@ -81,9 +81,9 @@ def dedupe_policy_shards(shards: Iterable["PolicyShard"], check_reverse: bool = 
 
     deduped_shards = deduped_shards + difference_shards
     if check_reverse:
-        deduped_shards = dedupe_policy_shards(reversed(deduped_shards), False)
+        deduped_shards = delineate_intersecting_shards(reversed(deduped_shards), False)
     if removed_shards or difference_shards:
-        deduped_shards = dedupe_policy_shards(deduped_shards)
+        deduped_shards = delineate_intersecting_shards(deduped_shards)
     return deduped_shards
 
 

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -327,13 +327,23 @@ class PolicyShard(BaseModel):
                 and not self.not_conditions.intersection(other.not_conditions)
             ):
                 return None
+
+        # intersection conditions/not_conditions cannot be a proper subset of self's as if they were they would include
+        # scenarios not originally included by self.
+        intersection_conditions = self.conditions.intersection(other.conditions)
+        if intersection_conditions < self.conditions:
+            intersection_conditions = self.conditions
+        intersection_not_conditions = self.not_conditions.intersection(other.not_conditions)
+        if intersection_not_conditions < self.conditions:
+            intersection_not_conditions = self.not_conditions
+
         return self.__class__(
             effect=self.effect,
             effective_action=intersection_action,
             effective_resource=intersection_resource,
             effective_principal=intersection_principal,
-            conditions=self.conditions.intersection(other.conditions),
-            not_conditions=self.not_conditions.intersection(other.not_conditions),
+            conditions=intersection_conditions,
+            not_conditions=intersection_not_conditions,
         )
 
     def issubset(self, other: object) -> bool:

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -407,7 +407,7 @@ class PolicyShard(BaseModel):
 
         return result
 
-    def _iter(self, *args, **kwargs) -> Iterator[Tuple[str, Any]]:
+    def _iter(self, *args, **kwargs) -> Iterator[Tuple[str, Any]]:  # type: ignore[override]
         for key, value in self.dict(*args, **kwargs).items():
             yield key, value
 

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -217,16 +217,6 @@ class PolicyShard(BaseModel):
         difference_resources = self.effective_resource.difference(other.effective_resource)
         difference_principals = self.effective_principal.difference(other.effective_principal)
 
-        if (
-            not difference_actions
-            and not difference_resources
-            and not difference_principals
-            and self.conditions == other.conditions
-            and self.not_conditions == other.not_conditions
-        ):
-            # Shards overlap wholly
-            return []
-
         result = []
         all_possible_combinations = [
             (action, resource, principal)

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -241,10 +241,8 @@ class PolicyShard(BaseModel):
         Parameters:
             other: The other PolicyShard to recompose this one with.
         """
-        intersection_action = self.effective_action.intersection(other.effective_action)
-        intersection_resource = self.effective_resource.intersection(other.effective_resource)
-        intersection_principal = self.effective_principal.intersection(other.effective_principal)
-        if not intersection_action or not intersection_resource or not intersection_principal:
+        intersection = self.intersection(other)
+        if not intersection:
             return []
         difference_actions = self.effective_action.difference(other.effective_action)
         difference_resources = self.effective_resource.difference(other.effective_resource)
@@ -252,9 +250,9 @@ class PolicyShard(BaseModel):
         result = []
         all_possible_combinations = [
             (action, resource, principal)
-            for action in [self.effective_action, intersection_action]
-            for resource in [self.effective_resource, intersection_resource]
-            for principal in [self.effective_principal, intersection_principal]
+            for action in [self.effective_action, intersection.effective_action]
+            for resource in [self.effective_resource, intersection.effective_resource]
+            for principal in [self.effective_principal, intersection.effective_principal]
         ]
         for action, resource, principal in all_possible_combinations:
             result.extend(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 long_description = re.sub(r":class:`~[^`]+\.([^`]+)`", "\1", long_description)
 
 setup(
-    version="0.4.7",
+    version="0.5.0",
     python_requires=">=3.6.0",
     name="policyglass",
     packages=find_packages(include=["policyglass", "policyglass.*"]),

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -18,6 +18,23 @@ def test_bad_difference():
 
 
 DIFFERENCE_SCENARIOS = {
+    "exactly_equal": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_resource=EffectiveResource(inclusion=Resource("*")),
+            effective_principal=EffectivePrincipal(Principal("AWS", "*")),
+            conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*")),
+            effective_resource=EffectiveResource(inclusion=Resource("*")),
+            effective_principal=EffectivePrincipal(Principal("AWS", "*")),
+            conditions=frozenset(),
+        ),
+        "result": [],
+    },
     "proper_subset": {
         "first": PolicyShard(
             effect="Allow",

--- a/tests/unit/equality/test_condition.py
+++ b/tests/unit/equality/test_condition.py
@@ -1,6 +1,6 @@
 import pytest
 
-from policyglass import Condition, ConditionCollection
+from policyglass import Condition, RawConditionCollection
 
 CONDITION_MATCH_SCENARIOS = {
     "exactly_equal": [
@@ -20,7 +20,7 @@ CONDITION_MATCH_SCENARIOS = {
 
 @pytest.mark.parametrize("_, scenario", CONDITION_MATCH_SCENARIOS.items())
 def test_condition_equality(_, scenario):
-    assert ConditionCollection(**scenario[0]) == ConditionCollection(**scenario[1])
+    assert RawConditionCollection(**scenario[0]) == RawConditionCollection(**scenario[1])
 
 
 CONDITION_NOT_MATCH_SCENARIOS = {
@@ -33,7 +33,7 @@ CONDITION_NOT_MATCH_SCENARIOS = {
 
 @pytest.mark.parametrize("_, scenario", CONDITION_NOT_MATCH_SCENARIOS.items())
 def test_condition_inequality(_, scenario):
-    assert ConditionCollection(**scenario[0]) != ConditionCollection(**scenario[1])
+    assert RawConditionCollection(**scenario[0]) != RawConditionCollection(**scenario[1])
 
 
 @pytest.mark.parametrize("_, scenario", CONDITION_MATCH_SCENARIOS.items())

--- a/tests/unit/equality/test_policy_shard.py
+++ b/tests/unit/equality/test_policy_shard.py
@@ -1,0 +1,82 @@
+import pytest
+
+from policyglass import PolicyShard
+from policyglass.action import Action, EffectiveAction
+from policyglass.condition import Condition
+from policyglass.principal import EffectivePrincipal, Principal
+from policyglass.resource import EffectiveResource, Resource
+
+SHARD_MATCH_SCENARIOS = {
+    "exactly_equal": [
+        [
+            PolicyShard(
+                effect="Deny",
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+                not_conditions=frozenset(),
+            )
+        ],
+        [
+            PolicyShard(
+                effect="Deny",
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                conditions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+                not_conditions=frozenset(),
+            )
+        ],
+    ]
+}
+
+
+@pytest.mark.parametrize("_, scenario", SHARD_MATCH_SCENARIOS.items())
+def test_shard_equality(_, scenario):
+    assert scenario[0] == scenario[1]
+
+
+SHARD_NOT_MATCH_SCENARIOS = {
+    "different_condition": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+    ],
+}
+
+
+@pytest.mark.parametrize("_, scenario", SHARD_NOT_MATCH_SCENARIOS.items())
+def test_sgard_inequality(_, scenario):
+    assert scenario[0] != scenario[1]

--- a/tests/unit/intersection/test_policy_shard.py
+++ b/tests/unit/intersection/test_policy_shard.py
@@ -195,6 +195,7 @@ INTERSECTION_SCENARIOS = {
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
             conditions=frozenset(
                 {
+                    Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
                     Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
                 }
             ),

--- a/tests/unit/intersection/test_policy_shard.py
+++ b/tests/unit/intersection/test_policy_shard.py
@@ -1,0 +1,203 @@
+import pytest
+
+from policyglass import PolicyShard
+from policyglass.action import Action, EffectiveAction
+from policyglass.condition import Condition
+from policyglass.principal import EffectivePrincipal, Principal
+from policyglass.resource import EffectiveResource, Resource
+
+
+def test_bad_intersection():
+    with pytest.raises(ValueError) as ex:
+        EffectiveAction(Action("S3:*")).intersection(Action("S3:*"))
+
+    assert "Cannot intersect EffectiveAction with Action" in str(ex.value)
+
+
+INTERSECTION_SCENARIOS = {
+    "test_action_subset": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset({}),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:GetObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset({}),
+            not_conditions=frozenset(),
+        ),
+    },
+    "test_exactly_equal": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset({}),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset({}),
+            not_conditions=frozenset(),
+        ),
+    },
+    "test_disjoint_conditions": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+        "result": None,
+    },
+    "test_matching_equal_one_with_one_without_condition": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+    },
+    "test_matching_subset_conditions_larger_first": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+                    Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+    },
+    "test_matching_subset_conditions_smaller_first": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+                    Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {
+                    Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+                }
+            ),
+            not_conditions=frozenset(),
+        ),
+    },
+}
+
+
+@pytest.mark.parametrize("_, scenario", INTERSECTION_SCENARIOS.items())
+def test_intersection(_, scenario):
+    first, second, result = scenario.values()
+    assert first.intersection(second) == result

--- a/tests/unit/intersection/test_policy_shard.py
+++ b/tests/unit/intersection/test_policy_shard.py
@@ -194,6 +194,38 @@ INTERSECTION_SCENARIOS = {
             not_conditions=frozenset(),
         ),
     },
+    "test_allow_without_condition_vs_deny_with_condition": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+        "second": PolicyShard(
+            effect="Deny",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+        "result": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ),
+    },
 }
 
 

--- a/tests/unit/intersection/test_policy_shard.py
+++ b/tests/unit/intersection/test_policy_shard.py
@@ -9,13 +9,20 @@ from policyglass.resource import EffectiveResource, Resource
 
 def test_bad_intersection():
     with pytest.raises(ValueError) as ex:
-        EffectiveAction(Action("S3:*")).intersection(Action("S3:*"))
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(),
+            not_conditions=frozenset(),
+        ).intersection(Action("S3:*"))
 
-    assert "Cannot intersect EffectiveAction with Action" in str(ex.value)
+    assert "Cannot intersect PolicyShard with Action" in str(ex.value)
 
 
 INTERSECTION_SCENARIOS = {
-    "test_action_subset": {
+    "test_subset": {
         "first": PolicyShard(
             effect="Allow",
             effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),

--- a/tests/unit/issubset/test_policy_shard.py
+++ b/tests/unit/issubset/test_policy_shard.py
@@ -95,6 +95,30 @@ POLICYS_SHARD_ISSUBSET_SCENARIOS = {
             conditions=frozenset({Condition(key="TestKey", operator="TestOperator", values=["TestValue"])}),
         ),
     ],
+    "exactly_equal_but_one_has_not_condition": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"])}
+            ),
+            not_conditions=frozenset(
+                {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+            ),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            conditions=frozenset(
+                {Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"])}
+            ),
+            not_conditions=frozenset(),
+        ),
+    ],
 }
 
 

--- a/tests/unit/pydantic_behaviour/test_policy.py
+++ b/tests/unit/pydantic_behaviour/test_policy.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from policyglass import ConditionCollection, Policy
+from policyglass import Policy, RawConditionCollection
 
 POLICIES = {
     "simple_iam_policy_strings": {
@@ -60,4 +60,4 @@ def test_policy_json_equality(_, policy):
 def test_policy_types(_, policy):
     subject = Policy(**policy).statement[0].condition
 
-    assert isinstance(subject, ConditionCollection) or subject is None
+    assert isinstance(subject, RawConditionCollection) or subject is None

--- a/tests/unit/test_delineate_intersecting_shards.py
+++ b/tests/unit/test_delineate_intersecting_shards.py
@@ -1,12 +1,12 @@
 from policyglass import PolicyShard
 from policyglass.action import Action, EffectiveAction
 from policyglass.condition import Condition
-from policyglass.policy_shard import dedupe_policy_shards
+from policyglass.policy_shard import delineate_intersecting_shards
 from policyglass.principal import EffectivePrincipal, Principal
 from policyglass.resource import EffectiveResource, Resource
 
 
-def test_dedupe_policy_shards_simple():
+def test_delineate_intersecting_shards_simple():
     shards = [
         PolicyShard(
             effect="Allow",
@@ -38,7 +38,7 @@ def test_dedupe_policy_shards_simple():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [
+    assert delineate_intersecting_shards(shards) == [
         PolicyShard(
             effect="Allow",
             effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
@@ -56,7 +56,7 @@ def test_dedupe_policy_shards_simple():
     ]
 
 
-def test_dedupe_policy_shards_complex_overlap():
+def test_delineate_intersecting_shards_complex_overlap():
     shards = [
         PolicyShard(
             effect="Allow",
@@ -74,7 +74,7 @@ def test_dedupe_policy_shards_complex_overlap():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [shards[1]]
+    assert delineate_intersecting_shards(shards) == [shards[1]]
 
 
 def test_larger_after_smaller():
@@ -106,7 +106,7 @@ def test_larger_after_smaller():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [shards[1]]
+    assert delineate_intersecting_shards(shards) == [shards[1]]
 
 
 def test_identical():
@@ -133,7 +133,7 @@ def test_identical():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [shards[1]]
+    assert delineate_intersecting_shards(shards) == [shards[1]]
 
 
 def test_identical_except_one_with_one_without_condition():
@@ -162,7 +162,7 @@ def test_identical_except_one_with_one_without_condition():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [shards[1]]
+    assert delineate_intersecting_shards(shards) == [shards[1]]
 
 
 def test_matching_subset_conditions():
@@ -192,7 +192,7 @@ def test_matching_subset_conditions():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [
+    assert delineate_intersecting_shards(shards) == [
         PolicyShard(
             effect="Allow",
             effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
@@ -249,7 +249,7 @@ def test_matching_subset_conditions_and_not_conditions():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == [
+    assert delineate_intersecting_shards(shards) == [
         PolicyShard(
             effect="Allow",
             effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
@@ -305,4 +305,4 @@ def test_subset_arps_differing_conditions():
         ),
     ]
 
-    assert dedupe_policy_shards(shards) == list(reversed(shards))
+    assert delineate_intersecting_shards(shards) == list(reversed(shards))


### PR DESCRIPTION
- Renamed `dedupe_policy_shards` to `dedupe_policy_shard_subsets` to differentiate it from `delineate_intersecting_shards`.
- Added `delineate_intersecting_shards` to reduce the size of `PolicyShard`s which have conditions whose ARPs intersect with ones without conditions.
    This helps clear up [#10](https://github.com/CloudWanderer-io/PolicyGlass/issues/10)
- Improved `issubset` on `PolicyShard` to recognise that a shard without conditions CANNOT be a subset of a shard with conditions.
- Added `<` and `>` to `PolicyShard`.
- Updated `difference` on `PolicyShard` so that it only adds `other`'s conditions to `self`'s not_conditions if self is allow and other is deny.
- Added documentation on how PolicyShard dedupe works
- Renamed `ConditionCollection` to `RawConditionCollection`
- Ensured that Conditions are always treated as a set not a list.
- Ensured that Condition's Operator, Key, Values are always of type ConditionOperator, ConditionKey and ConditionValue.
- Corrected bug in `CaseInsensitiveString` that caused it to generate case sensitive hashes.
- Added `dedupe_result` param to `difference` method on `PolicyShard` to allow merging of intersecting shards that are not subsets of one another.
- Added `intersection` to `PolicyShard`.
- Prevent attempting to calculate the difference between a Deny shard and an Allow shard. Other way makes sense as that's effective permission.
- Updated PolicyShard implementation to Support pydantic 1.9