### PR TITLE
dedupe_policy_shards now sorts input by effective_resource, improving…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 0.8.0
 
 - `dedupe_policy_shard_subsets` now sorts input by `effective_resource` improving readability in scenarios with simple denies that deny both Action and Resource.
+- Added `union` to `EffectiveCondition`
+- Added `reverse` to `EffectiveCondition`
+- Fixed bug causing denies with multiple ARPs to deny more than they should because `PolicyShard.difference` didn't generate shards that accounted for one of the ARPs not being met.
+- Split out `_decompose_difference` into `_decompose_difference_arps_with_combined_conditions` and `_decompose_difference_arps_with_self_conditions`
+
 # 0.7.0
 
 - Added `__bool__` and `intersection` to `EffectiveCondition`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.8.0
+
+- `dedupe_policy_shard_subsets` now sorts input by `effective_resource` improving readability in scenarios with simple denies that deny both Action and Resource.
 # 0.7.0
 
 - Added `__bool__` and `intersection` to `EffectiveCondition`

--- a/doc_source/examples_policy_analysis.rst
+++ b/doc_source/examples_policy_analysis.rst
@@ -57,11 +57,11 @@ To understand the policy, let's get the :meth:`~policyglass.policy_shard.policy_
     >>> test_policy_shards = policy_shards_effect(test_policy.policy_shards)
     >>> explain_policy_shards(test_policy_shards)
     ["Allow action s3:PutObject on resource * (except for arn:aws:s3:::examplebucket/*) with principal AWS *. 
-        Provided conditions s3:TlsVersion NumericLessThan ['1.2'] and 
-            s3:x-amz-server-side-encryption StringEquals ['AES256'] are met.", 
-    "Allow action s3:* (except for s3:PutObject) on resource * with principal AWS *. 
+        Provided conditions s3:TlsVersion NumericLessThan ['1.2'] and s3:x-amz-server-side-encryption StringEquals ['AES256'] are met.", 
+    "Allow action s3:* (except for s3:PutObject) on resource * (except for arn:aws:s3:::examplebucket/*) with principal AWS *. 
         Provided conditions s3:TlsVersion NumericLessThan ['1.2'] are met.", 
-    'Allow action s3:PutObject on resource arn:aws:s3:::examplebucket/* with principal AWS *.']
+    'Allow action s3:* on resource arn:aws:s3:::examplebucket/* with principal AWS *.']
+
 
 That helps clarify what the policy results in for humans. But what if we want to programatically ask a question about what this allows?
 

--- a/policyglass/condition.py
+++ b/policyglass/condition.py
@@ -200,6 +200,28 @@ class EffectiveCondition(BaseModel):
             exclusions=self.exclusions.intersection(other.exclusions),
         )
 
+    def union(self, other: object) -> "EffectiveCondition":
+        """Combine this object with another object of the same type.
+
+        Parameters:
+            other: The object to combine with this one.
+
+        Raises:
+            ValueError: If ``other`` is not the same type as this object.
+        """
+        if not isinstance(other, self.__class__):
+            raise ValueError(f"Cannot union {self.__class__.__name__} with {other.__class__.__name__}")
+
+        return self.__class__(self.inclusions.union(other.inclusions), self.exclusions.union(other.exclusions))
+
+    @property
+    def reverse(self) -> "EffectiveCondition":
+        """Reverse the effect of this EffectiveCondition."""
+        return self.__class__(
+            inclusions=self.exclusions,
+            exclusions=self.inclusions,
+        )
+
     def dict(self, *args, **kwargs) -> Dict[str, Any]:
         """Convert instance to dict representation of it.
 

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -21,7 +21,12 @@ def dedupe_policy_shard_subsets(shards: Iterable["PolicyShard"], check_reverse: 
     """
     deduped_shards: List[PolicyShard] = []
     removed_shards: List[PolicyShard] = []
-    for undeduped_shard in shards:
+
+    # Sorting by effective resource means that PolicyShards with larger resources will have any subsets
+    # folded into them first, improving readability
+    sorted_shards = sorted(shards, key=lambda x: x.effective_resource)
+
+    for undeduped_shard in sorted_shards:
         if any(undeduped_shard.issubset(deduped_shard) for deduped_shard in deduped_shards):
             removed_shards.append(undeduped_shard)
             continue

--- a/policyglass/policy_shard.py
+++ b/policyglass/policy_shard.py
@@ -21,10 +21,13 @@ def dedupe_policy_shard_subsets(shards: Iterable["PolicyShard"], check_reverse: 
     """
     deduped_shards: List[PolicyShard] = []
     removed_shards: List[PolicyShard] = []
+    sorted_shards = shards
 
     # Sorting by effective resource means that PolicyShards with larger resources will have any subsets
-    # folded into them first, improving readability
-    sorted_shards = sorted(shards, key=lambda x: x.effective_resource)
+    # folded into them first, improving readability. We only do this whenn check_reverse is true otherwise
+    # we won't respect the reverse order.
+    if check_reverse:
+        sorted_shards = sorted(shards, key=lambda x: x.effective_resource, reverse=True)
 
     for undeduped_shard in sorted_shards:
         if any(undeduped_shard.issubset(deduped_shard) for deduped_shard in deduped_shards):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 long_description = re.sub(r":class:`~[^`]+\.([^`]+)`", "\1", long_description)
 
 setup(
-    version="0.7.0",
+    version="0.8.0",
     python_requires=">=3.6.0",
     name="policyglass",
     packages=find_packages(include=["policyglass", "policyglass.*"]),

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -368,6 +368,73 @@ DIFFERENCE_SCENARIOS = {
             ),
         ],
     },
+    "test_subset_arps_differing_conditions_allow_and_deny": {
+        "first": PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(
+                inclusions=frozenset(
+                    {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                ),
+                exclusions=frozenset(),
+            ),
+        ),
+        "second": PolicyShard(
+            effect="Deny",
+            effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(
+                inclusions=frozenset(
+                    {Condition(key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"])}
+                ),
+                exclusions=frozenset(),
+            ),
+        ),
+        "result": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(
+                    inclusions=frozenset(
+                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                    ),
+                    exclusions=frozenset(),
+                ),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(
+                    inclusions=frozenset(
+                        {
+                            Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
+                            Condition(
+                                key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]
+                            ),
+                        }
+                    ),
+                    exclusions=frozenset(),
+                ),
+            ),
+        ],
+    },
 }
 
 

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -414,20 +414,34 @@ DIFFERENCE_SCENARIOS = {
             ),
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
-                effective_resource=EffectiveResource(
-                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                effective_action=EffectiveAction(
+                    inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
                 ),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(
+                    inclusions=frozenset(
+                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                    ),
+                    exclusions=frozenset(),
+                ),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
                 effective_condition=EffectiveCondition(
                     inclusions=frozenset(
                         {
-                            Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
                             Condition(
                                 key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]
                             ),
+                            Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"]),
                         }
                     ),
                     exclusions=frozenset(),

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -283,23 +283,11 @@ DIFFERENCE_SCENARIOS = {
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
         ),
         "result": [
-            # The duplication in this output will get resolved by `dedupe_policy_shards`
             PolicyShard(
                 effect="Allow",
                 effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
                     inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
-                ),
-                effective_principal=EffectivePrincipal(
-                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-                ),
-                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
-            ),
-            PolicyShard(
-                effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
-                effective_resource=EffectiveResource(
-                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
                 ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
@@ -315,7 +303,6 @@ DIFFERENCE_SCENARIOS = {
                 ),
                 effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
             ),
-
         ],
     },
     "test_allow_with_exclusions": {

--- a/tests/unit/difference/test_policyshard.py
+++ b/tests/unit/difference/test_policyshard.py
@@ -283,14 +283,7 @@ DIFFERENCE_SCENARIOS = {
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
         ),
         "result": [
-            PolicyShard(
-                effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
-                effective_principal=EffectivePrincipal(
-                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-                ),
-            ),
+            # The duplication in this output will get resolved by `dedupe_policy_shards`
             PolicyShard(
                 effect="Allow",
                 effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
@@ -300,7 +293,29 @@ DIFFERENCE_SCENARIOS = {
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
             ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+            ),
+
         ],
     },
     "test_allow_with_exclusions": {

--- a/tests/unit/issubset/test_effective_action.py
+++ b/tests/unit/issubset/test_effective_action.py
@@ -48,8 +48,15 @@ def test_union_complex_overlap():
     assert a.issubset(b) is False
 
 
-def test_exclusion_not_subset_of_no_exclusion():
+def test_no_exclusion_not_subset_of_exclusion():
 
     a = EffectiveAction(inclusion=Action("*"), exclusions=frozenset())
     b = EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:getobject")}))
     assert a.issubset(b) is False
+
+
+def test_exclusion_subset_of_no_exclusion():
+
+    a = EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:getobject")}))
+    b = EffectiveAction(inclusion=Action("*"), exclusions=frozenset())
+    assert a.issubset(b)

--- a/tests/unit/issubset/test_policy_shard.py
+++ b/tests/unit/issubset/test_policy_shard.py
@@ -18,6 +18,22 @@ POLICYS_SHARD_ISSUBSET_SCENARIOS = {
             effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
         ),
     ],
+    "smaller_by_arp_exclusion": [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:Get*")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+    ],
     "exactly_equal": [
         PolicyShard(
             effect="Allow",

--- a/tests/unit/test_delineate_intersecting_shards.py
+++ b/tests/unit/test_delineate_intersecting_shards.py
@@ -295,3 +295,54 @@ def test_subset_arps_differing_conditions():
     ]
 
     assert dedupe_policy_shards(shards) == list(reversed(shards))
+
+
+def test_result_of_denying_action_and_resource():
+    shards = [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+    ]
+
+    assert dedupe_policy_shards(shards) == [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("S3:PutObject")})),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+    ]

--- a/tests/unit/test_delineate_intersecting_shards.py
+++ b/tests/unit/test_delineate_intersecting_shards.py
@@ -346,3 +346,47 @@ def test_result_of_denying_action_and_resource():
             effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
         ),
     ]
+
+
+def test_result_of_difference_of_deny_action_and_resource_subsets():
+    # This corresponds to the output of difference/test_policyshard::deny_action_and_resource_subsets
+    # And demonstrates that counterintuitive output is resolved by dedupe_policy_shards
+    shards = [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+    ]
+
+    assert dedupe_policy_shards(shards) == [
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+        PolicyShard(
+            effect="Allow",
+            effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+            effective_resource=EffectiveResource(
+                inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+            ),
+            effective_principal=EffectivePrincipal(inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()),
+            effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+        ),
+    ]

--- a/tests/unit/test_effective_condition.py
+++ b/tests/unit/test_effective_condition.py
@@ -26,3 +26,26 @@ def test_factory():
             },
         ),
     )
+
+
+def test_reverse():
+
+    subject = EffectiveCondition(
+        inclusions=frozenset({Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}),
+        exclusions=frozenset(
+            {
+                Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                Condition(key="key", operator="BinaryEquals", values=["QmluYXJ5VmFsdWVJbkJhc2U2NA=="]),
+            },
+        ),
+    )
+
+    assert subject.reverse == EffectiveCondition(
+        frozenset(
+            {
+                Condition(key="s3:x-amz-server-side-encryption", operator="StringEquals", values=["AES256"]),
+                Condition(key="aws:PrincipalOrgId", operator="StringEquals", values=["o-123456"]),
+                Condition(key="key", operator="BinaryEquals", values=["QmluYXJ5VmFsdWVJbkJhc2U2NA=="]),
+            }
+        )
+    )

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -268,6 +268,35 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
         "expected": [
             PolicyShard(
                 effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(
+                    inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
+                ),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(
+                    inclusions=frozenset(
+                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                    ),
+                    exclusions=frozenset(),
+                ),
+            ),
+            PolicyShard(
+                effect="Allow",
                 effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
                     inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
@@ -286,31 +315,6 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                             )
                         }
                     ),
-                ),
-            ),
-            PolicyShard(
-                effect="Allow",
-                effective_action=EffectiveAction(
-                    inclusion=Action("s3:*"), exclusions=frozenset({Action("s3:PutObject")})
-                ),
-                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
-                effective_principal=EffectivePrincipal(
-                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
-                ),
-                effective_condition=EffectiveCondition(
-                    inclusions=frozenset(
-                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-                    )
-                ),
-            ),
-            PolicyShard(
-                effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
-                effective_resource=EffectiveResource(
-                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
-                ),
-                effective_principal=EffectivePrincipal(
-                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
             ),
         ],

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -303,7 +303,6 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                     inclusions=frozenset(
                         {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
                     ),
-                    exclusions=frozenset(),
                 ),
             ),
             PolicyShard(
@@ -311,6 +310,49 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
                 effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
                     inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+            ),
+        ],
+    },
+    "deny_action_and_resource_subsets": {
+        "input": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("*"), exclusions=frozenset()),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+            ),
+            PolicyShard(
+                effect="Deny",
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(inclusion=Resource("arn:aws:s3:::examplebucket/*")),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+            ),
+        ],
+        "expected": [
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset({Action("s3:PutObject")})),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                ),
+                effective_principal=EffectivePrincipal(
+                    inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
+                ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+            ),
+            PolicyShard(
+                effect="Allow",
+                effective_action=EffectiveAction(inclusion=Action("*"), exclusions=frozenset()),
+                effective_resource=EffectiveResource(
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
                 ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()

--- a/tests/unit/test_policy_shards_effect.py
+++ b/tests/unit/test_policy_shards_effect.py
@@ -268,14 +268,25 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
         "expected": [
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
+                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
-                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
+                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
                 ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
+                effective_condition=EffectiveCondition(
+                    inclusions=frozenset(
+                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
+                    ),
+                    exclusions=frozenset(
+                        {
+                            Condition(
+                                key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"]
+                            )
+                        }
+                    ),
+                ),
             ),
             PolicyShard(
                 effect="Allow",
@@ -297,25 +308,14 @@ POLICY_SHARDS_EFFECT_SCENARIOS = {
             ),
             PolicyShard(
                 effect="Allow",
-                effective_action=EffectiveAction(inclusion=Action("s3:PutObject"), exclusions=frozenset()),
+                effective_action=EffectiveAction(inclusion=Action("s3:*"), exclusions=frozenset()),
                 effective_resource=EffectiveResource(
-                    inclusion=Resource("*"), exclusions=frozenset({Resource("arn:aws:s3:::examplebucket/*")})
+                    inclusion=Resource("arn:aws:s3:::examplebucket/*"), exclusions=frozenset()
                 ),
                 effective_principal=EffectivePrincipal(
                     inclusion=Principal(type="AWS", value="*"), exclusions=frozenset()
                 ),
-                effective_condition=EffectiveCondition(
-                    inclusions=frozenset(
-                        {Condition(key="aws:PrincipalOrgId", operator="StringNotEquals", values=["o-123456"])}
-                    ),
-                    exclusions=frozenset(
-                        {
-                            Condition(
-                                key="s3:x-amz-server-side-encryption", operator="StringNotEquals", values=["AES256"]
-                            )
-                        }
-                    ),
-                ),
+                effective_condition=EffectiveCondition(inclusions=frozenset(), exclusions=frozenset()),
             ),
         ],
     },

--- a/tests/unit/union/test_effective_condition.py
+++ b/tests/unit/union/test_effective_condition.py
@@ -1,0 +1,38 @@
+from policyglass import Condition, EffectiveCondition
+
+
+def test_different_inclusions():
+    effective_condition_a = EffectiveCondition(frozenset({Condition("Key", "Operator", ["value"])}))
+    effective_condition_b = EffectiveCondition(frozenset({Condition("AnotherKey", "Operator", ["value"])}))
+
+    assert effective_condition_a.union(effective_condition_b) == EffectiveCondition(
+        frozenset({Condition("Key", "Operator", ["value"]), Condition("AnotherKey", "Operator", ["value"])}),
+    )
+
+
+def test_same_inclusions():
+    effective_condition_a = EffectiveCondition(frozenset({Condition("Key", "Operator", ["value"])}))
+    effective_condition_b = EffectiveCondition(frozenset({Condition("Key", "Operator", ["value"])}))
+
+    assert effective_condition_a.union(effective_condition_b) == EffectiveCondition(
+        frozenset({Condition("Key", "Operator", ["value"])})
+    )
+
+
+def test_different_exclusions():
+    effective_condition_a = EffectiveCondition(frozenset(), frozenset({Condition("Key", "Operator", ["value"])}))
+    effective_condition_b = EffectiveCondition(frozenset(), frozenset({Condition("AnotherKey", "Operator", ["value"])}))
+
+    assert effective_condition_a.union(effective_condition_b) == EffectiveCondition(
+        frozenset(),
+        frozenset({Condition("Key", "Operator", ["value"]), Condition("AnotherKey", "Operator", ["value"])}),
+    )
+
+
+def test_same_exclusions():
+    effective_condition_a = EffectiveCondition(frozenset(), frozenset({Condition("Key", "Operator", ["value"])}))
+    effective_condition_b = EffectiveCondition(frozenset(), frozenset({Condition("Key", "Operator", ["value"])}))
+
+    assert effective_condition_a.union(effective_condition_b) == EffectiveCondition(
+        frozenset(), frozenset({Condition("Key", "Operator", ["value"])})
+    )


### PR DESCRIPTION
… readability

- `dedupe_policy_shard_subsets` now sorts input by `effective_resource` improving readability in scenarios with simple denies that deny both Action and Resource.
- Added `union` to `EffectiveCondition`
- Added `reverse` to `EffectiveCondition`
- Fixed bug causing denies with multiple ARPs to deny more than they should because `PolicyShard.difference` didn't generate shards that accounted for one of the ARPs not being met.
- Split out `_decompose_difference` into `_decompose_difference_arps_with_combined_conditions` and `_decompose_difference_arps_with_self_conditions`